### PR TITLE
Hide empty images

### DIFF
--- a/src/AuctionDetail.tsx
+++ b/src/AuctionDetail.tsx
@@ -94,7 +94,9 @@ function AuctionDetail() {
                 <h1>{item.title}</h1>
                 <div className="auction-overview">
                     <div className="overview-description">{item.description}</div>
-                    <div className="overview-image"><img src={getImageSource(item.image)} /></div>
+                    {!!item.image?.length && (
+                        <div className="overview-image"><img src={getImageSource(item.image)} /></div>
+                    )}
                 </div>
             </>
         );

--- a/src/AuctionList.tsx
+++ b/src/AuctionList.tsx
@@ -16,7 +16,7 @@ function AuctionList() {
             <li key={id} className="gallery-item" onClick={(_) => navigate(navigationLink(id))}>
                 <div className="auction-title">{overview.item.title}</div>
                 <div className="auction-description">{overview.item.description}</div>
-                <img src={getImageSource(overview.item.image)} />
+                {!!overview.item.image?.length && <img src={getImageSource(overview.item.image)} />}
                 <div className="gallery-item-link">
                     <Link to={navigationLink(id)}>Auction details</Link>
                 </div>


### PR DESCRIPTION
Removes the ![<-]() nonexistent image icon from the auction list / detail when an image is not provided for the auction. 